### PR TITLE
feat. branch: stability with xelatex

### DIFF
--- a/download.php
+++ b/download.php
@@ -48,7 +48,7 @@
             $filename = $_SESSION["filename"]; // output file name
 
             $userMarkdown = $_SESSION["user-input"];
-            $conversion = "pandoc -f markdown+hard_line_breaks output/'$convert' -t beamer -o output/'$filename' --pdf-engine=xelatex";
+            $conversion = "pandoc -f markdown+hard_line_breaks output/'$convert' -t beamer -o output/'$filename' --pdf-engine=lualatex --include-in-header=output/header.tex";
 
             shell_exec("echo '$userMarkdown' > output/'$push'");
             shell_exec("cat $templateFile output/'$push' > output/'$convert'");

--- a/download.php
+++ b/download.php
@@ -48,7 +48,7 @@
             $filename = $_SESSION["filename"]; // output file name
 
             $userMarkdown = $_SESSION["user-input"];
-            $conversion = "pandoc -f markdown+hard_line_breaks output/'$convert' -t beamer -o output/'$filename' --pdf-engine=lualatex --include-in-header=output/header.tex";
+            $conversion = "pandoc -f markdown+hard_line_breaks output/'$convert' -t beamer -o output/'$filename' --pdf-engine=xelatex --include-in-header=output/header.tex";
 
             shell_exec("echo '$userMarkdown' > output/'$push'");
             shell_exec("cat $templateFile output/'$push' > output/'$convert'");

--- a/download.php
+++ b/download.php
@@ -48,7 +48,7 @@
             $filename = $_SESSION["filename"]; // output file name
 
             $userMarkdown = $_SESSION["user-input"];
-            $conversion = "pandoc -f markdown+hard_line_breaks output/'$convert' -t beamer -o output/'$filename' --pdf-engine=pdflatex";
+            $conversion = "pandoc -f markdown+hard_line_breaks output/'$convert' -t beamer -o output/'$filename' --pdf-engine=xelatex";
 
             shell_exec("echo '$userMarkdown' > output/'$push'");
             shell_exec("cat $templateFile output/'$push' > output/'$convert'");

--- a/output/header.tex
+++ b/output/header.tex
@@ -1,0 +1,3 @@
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{emoji}

--- a/output/header.tex
+++ b/output/header.tex
@@ -1,3 +1,3 @@
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
-\usepackage{emoji}
+\usepackage{fontspec}


### PR DESCRIPTION
## feat. branch: stability with xelatex
initial goal of this branch was to provide better unicode support, I soon found out that `xelatex` would be a better option to avoid the bug wherein slides would be blank when users input unicode characters. I think that would be a more useful thing to have right now.